### PR TITLE
preferCache method (work-in-progress)

### DIFF
--- a/test/prefer-cache.test.ts
+++ b/test/prefer-cache.test.ts
@@ -1,0 +1,28 @@
+import { Normi } from '../src';
+
+test('prefer-cache test (for e.g. stale api responses)', () => {
+  const normi = new Normi();
+
+  const id = '3d16368b-79cc-48f4-8b72-e514ec99315c';
+  const originalPost = {
+    id,
+    title: 'first post',
+    updatedAt: '2021-02-01T00:31:00.000Z',
+  };
+  const updatedPost = {
+    id,
+    title: 'Hello, normi!',
+    updatedAt: '2021-02-01T00:31:20.000Z',
+  };
+  normi.merge(originalPost);
+  // we just did a mutation
+  normi.merge(updatedPost);
+
+  expect(normi.getPreferCache(originalPost).value).toEqual(updatedPost);
+
+  const objNotInCache = {
+    id: '7c22ad2a-641a-11eb-ae93-0242ac130002',
+    title: 'test',
+  };
+  expect((normi.getPreferCache(objNotInCache.value)).toEqual(objNotInCache);
+});


### PR DESCRIPTION
would be nice when working when react-query and you have a stale API-request that you'd prefer to pick up from the normi cache


mock code: 

```ts
const res = useQuery(/*...*/)

const data = res.isStale ? normi.preferCache(res.data) : normi.merge(data)
return {
  ...res,
  data,
}
```
